### PR TITLE
Upgraded nuget packages to .NET Core 2.2

### DIFF
--- a/BridgeProtocol.Integrations.NetworkPartner.Site/BridgeProtocol.Integrations.NetworkPartner.Site.csproj
+++ b/BridgeProtocol.Integrations.NetworkPartner.Site/BridgeProtocol.Integrations.NetworkPartner.Site.csproj
@@ -1,20 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\bridge-protocol-integrations-dotnet\BridgeProtocol.Integrations\BridgeProtocol.Integrations.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>
     <Folder Include="wwwroot\scripts\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\bridge-protocol-integrations-dotnet\BridgeProtocol.Integrations\BridgeProtocol.Integrations.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Upgraded nuget packages to .NET Core 2.2 to properly reference the .NET Standard update to the .NET integrations library